### PR TITLE
Add ignore options to continue operation on secret pull failures.

### DIFF
--- a/pkg/numericutil/numericutil.go
+++ b/pkg/numericutil/numericutil.go
@@ -1,9 +1,22 @@
 package numericutil
 
-func BoolToUint8(b bool) uint8 {
+import "github.com/alphaflow/injector/pkg/stringutil"
+
+// BoolToInt returns `1` for a `true` boolean value and `0` for a false boolean value.
+func BoolToInt(b bool) int {
 	if b {
 		return 1
 	}
 
 	return 0
+}
+
+// StringToBool returns `true` for a non-blank string and `false` for a blank string.
+func StringToBool(s string) bool {
+	return !stringutil.IsBlank(s)
+}
+
+// StringToBoolInt returns `1` for a non-blank string and `0` for a blank string.
+func StringToBoolInt(s string) int {
+	return BoolToInt(StringToBool(s))
 }


### PR DESCRIPTION
There needs to be a way to handle local testing wherein some secret pull options may have been hardcoded or injected by the container via k8s but not necessarily available when run locally.

This PR changes behavior so that if no retrieval options have been specified (either via cli or env vars) then operation will continue without a secret fetch attempt. On the other hand, if all retrieval options have been specified but aren't necessarily valid, this PR introduces two new flags which will allow operation to continue even after a fetch has failed:

-- `ignore (-i)`
-- `ignore-preserve-env (-I)`

The `ignore (-i)` option tells the injector to ignore fetch failures and just continue without injecting environment variables (unless combined with the existing `-E` option).

The `ignore-preserve-env (-I)` option tells the injector to ignore fetch failure and continue but also inject existing parent process environment variables. This option can also be used to provide a fallback in case a particular configured secret has disappeared (possible deleted if specifying a `secret-version` or become unavailable (possibly due to a GCP outage or similar failure).