### PR TITLE
Remove quoting of env var values injected into the child shell environment.

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ const (
 	appName                     = "inject"
 	unexportedOutputFormatter   = `%s="%s"`
 	exportedOutputFormatter     = `export %s="%s"`
+	unquotedOutputFormatter     = `%s=%s`
 	jsonIndent                  = `    `
 	envVarInjectorKeyValue      = "INJECTOR_KEY_VALUE"
 	envVarInjectorProject       = "INJECTOR_PROJECT"
@@ -411,7 +412,7 @@ func convertMapToKeyValueList(ctx *cli.Context, data map[string]interface{}) ([]
 		return []string{}, err
 	}
 
-	return jsonutil.Flatten(jsonBytes, "environment", unexportedOutputFormatter), nil
+	return jsonutil.Flatten(jsonBytes, "environment", unquotedOutputFormatter), nil
 }
 
 // outputShellExported writes the secret manager document contents as exported shell key/value variables to the

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ import (
 
 const (
 	appName                     = "inject"
-	unexportedOutputFormatter   = `%s="%s"`
 	exportedOutputFormatter     = `export %s="%s"`
+	unexportedOutputFormatter   = `%s="%s"`
 	unquotedOutputFormatter     = `%s=%s`
 	jsonIndent                  = `    `
 	envVarInjectorKeyValue      = "INJECTOR_KEY_VALUE"
@@ -418,13 +418,13 @@ func convertMapToKeyValueList(ctx *cli.Context, data map[string]interface{}) ([]
 // outputShellExported writes the secret manager document contents as exported shell key/value variables to the
 // specified io.Writer.
 func outputShellExported(ctx *cli.Context, buffer *bytes.Buffer, writer io.Writer) error {
-	return outputShell(ctx, buffer, writer, unexportedOutputFormatter)
+	return outputShell(ctx, buffer, writer, exportedOutputFormatter)
 }
 
 // outputShellUnexported writes the secret manager document contents as unexported shell key/value variables to the
 // specified io.Writer.
 func outputShellUnexported(ctx *cli.Context, buffer *bytes.Buffer, writer io.Writer) error {
-	return outputShell(ctx, buffer, writer, exportedOutputFormatter)
+	return outputShell(ctx, buffer, writer, unexportedOutputFormatter)
 }
 
 // outputShell writes the secret manager document contents as shell environment variables, formatted with the given


### PR DESCRIPTION
Env vars are being injected with quoted values (that is, the values themselves are wrapped with quotes) which is undesirable. This PR fixes that and also fixes the fact that the exported vs unexported shell output options were reversed.